### PR TITLE
Fix Memory Leak

### DIFF
--- a/Client/Connection.cs
+++ b/Client/Connection.cs
@@ -55,6 +55,7 @@ namespace CardGame.Client
         public override void _ExitTree()
         {
             Client?.CloseConnection();
+            QueueFree();
         }
     }
 }

--- a/Server/Connection.cs
+++ b/Server/Connection.cs
@@ -61,6 +61,7 @@ namespace CardGame.Server
         public override void _ExitTree()
         {
             Server?.CloseConnection();
+            QueueFree();
         }
     }
 }

--- a/Tests/test_metadata.json
+++ b/Tests/test_metadata.json
@@ -25,7 +25,7 @@
 		"tags": [
 
 		],
-		"passing": false
+		"passing": true
 	},
 	"res://Tests/ServerTest.cs": {
 		"path": "res://Tests/ServerTest.cs",


### PR DESCRIPTION
There are still five orphan string names from signals in WAT
but as established elsewhere this is a bug with godot signals in
CSharp and not our issue to deal with.